### PR TITLE
fix (HelloWorldWidget): adjusted example name to not contain spaces

### DIFF
--- a/widgets/hello-world.php
+++ b/widgets/hello-world.php
@@ -19,7 +19,7 @@ class Hello_World_Widget extends \Elementor\Widget_Base {
 	 * @return string Widget name.
 	 */
 	public function get_name() {
-		return 'Hello World';
+		return 'hello-world';
 	}
 
 	/**


### PR DESCRIPTION
get_name() is used [to generate the widget wrapper class name](https://github.com/elementor/elementor/blob/fab0d46aac98a4b09a92b7a0a7bf4fcbe1942b46/includes/base/widget-base.php#L442) 
and spaces dont work nicely in CSS class names 

The originally selected name "Hello World" made me to choose similar names for my widgets with spaces and that caused hours of debugging because the JS was not finding its way to display the controllers.

This "fix" simply adjusts the example widget name to follow a "CSS class name"-compatible pattern